### PR TITLE
Fixed linker error due to missing -fPIC on cmake build stage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ project(gl3w)
 
 cmake_minimum_required(VERSION 2.8.12)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
 # add and depend on OpenGL
 find_package(OpenGL REQUIRED)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class Gl3wConan(ConanFile):
             shutil.rmtree("gl3w")
         # download and generate the sources
         tools.download(
-            "https://github.com/skaslev/gl3w/raw/master/gl3w_gen.py",
+            "https://raw.githubusercontent.com/skaslev/gl3w/4f1d558410b0938840dc3db98e741d71f382ba22/gl3w_gen.py",
             "gl3w_gen.py")
         self.run("python gl3w_gen.py --root gl3w")
 


### PR DESCRIPTION
I fixed a linker error while trying to link gl3w static library into a shared library. The error was caused because -fPIC was not properly set. This can be seen on build logs:

```
joaquin@debian:~/Documents/test$ conan install . --build missing -pr=dev
Configuration:
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++11
compiler.version=6
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

conanfile.txt: Installing package
Requirements
    gl3w/0.2@tuebel/testing from local cache - Cache
Packages
    gl3w/0.2@tuebel/testing:d0ec62fc032e5a10524fa454546aa1bdbb22baf8 - Build

gl3w/0.2@tuebel/testing: Building your package in /home/joaquin/.conan/data/gl3w/0.2/tuebel/testing/build/d0ec62fc032e5a10524fa454546aa1bdbb22baf8
gl3w/0.2@tuebel/testing: Copying sources to build folder
gl3w/0.2@tuebel/testing: Generator cmake created conanbuildinfo.cmake
gl3w/0.2@tuebel/testing: Calling build()
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libGL.so   
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DATAROOTDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_OLDINCLUDEDIR
    CMAKE_INSTALL_SBINDIR
    CONAN_CMAKE_POSITION_INDEPENDENT_CODE
    CONAN_COMPILER
    CONAN_COMPILER_VERSION
    CONAN_CXX_FLAGS
    CONAN_C_FLAGS
    CONAN_EXPORTED
    CONAN_IN_LOCAL_CACHE
    CONAN_LIBCXX
    CONAN_SHARED_LINKER_FLAGS


-- Build files have been written to: /home/joaquin/.conan/data/gl3w/0.2/tuebel/testing/build/d0ec62fc032e5a10524fa454546aa1bdbb22baf8
Scanning dependencies of target gl3w
[ 50%] Building C object CMakeFiles/gl3w.dir/gl3w/src/gl3w.c.o
[100%] Linking C static library libgl3w.a
[100%] Built target gl3w
gl3w/0.2@tuebel/testing: Package 'd0ec62fc032e5a10524fa454546aa1bdbb22baf8' built
gl3w/0.2@tuebel/testing: Build folder /home/joaquin/.conan/data/gl3w/0.2/tuebel/testing/build/d0ec62fc032e5a10524fa454546aa1bdbb22baf8
gl3w/0.2@tuebel/testing: Generated conaninfo.txt
gl3w/0.2@tuebel/testing: Generated conanbuildinfo.txt
gl3w/0.2@tuebel/testing: Generating the package
gl3w/0.2@tuebel/testing: Package folder /home/joaquin/.conan/data/gl3w/0.2/tuebel/testing/package/d0ec62fc032e5a10524fa454546aa1bdbb22baf8
gl3w/0.2@tuebel/testing: Calling package()
gl3w/0.2@tuebel/testing package(): Copied 1 '.a' file: libgl3w.a
gl3w/0.2@tuebel/testing package(): Copied 3 '.h' files: khrplatform.h, glcorearb.h, gl3w.h
gl3w/0.2@tuebel/testing: Package 'd0ec62fc032e5a10524fa454546aa1bdbb22baf8' created
```

We can see that CONAN_CMAKE_POSITION_INDEPENDENT_CODE was not used despite the fact that the conan recipe is correct and the library was built successfully.

The symbol relocation error shows as:

```
joaquin@debian:~/Documents/test$ cmake . -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-- Current conanbuildinfo.cmake directory: /home/joaquin/Documents/test
-- Conan: Compiler GCC>=5, checking major version 6
-- Conan: Checking correct version: 6
-- Conan: Using cmake global configuration
-- Conan: Adjusting default RPATHs Conan policies
-- Conan: Adjusting language standard
-- ----- Building parser_test -----
-- Configuring done
-- Generating done
-- Build files have been written to: /home/joaquin/Documents/test
joaquin@debian:~/Documents/test$ cmake --build . --config Release
[ 12%] Linking CXX shared library lib/libparser.so
/usr/bin/ld: /home/joaquin/.conan/data/gl3w/0.2/tuebel/testing/package/d0ec62fc032e5a10524fa454546aa1bdbb22baf8/lib/libgl3w.a(gl3w.c.o): relocation R_X86_64_PC32 against symbol `gl3wProcs' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
CMakeFiles/parser.dir/build.make:143: recipe for target 'lib/libparser.so' failed
make[2]: *** [lib/libparser.so] Error 1
CMakeFiles/Makefile2:72: recipe for target 'CMakeFiles/parser.dir/all' failed
make[1]: *** [CMakeFiles/parser.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

Now it should be working properly.

I also modified the conanfile.py to point to a concrete gl3w commit. Pointing to master can be dangerous because a new commit can broke the build. I would change that url to point to a concrete version tag when it is available.